### PR TITLE
Allow parsing the "bind all addresses" IPv6 address

### DIFF
--- a/src/Network/HostAndPort.hs
+++ b/src/Network/HostAndPort.hs
@@ -81,7 +81,7 @@ ipv6address = do
                         ++ [try full]
                         ++ (try <$> skippedAtMiddle)
                         ++ (try <$> skippedAtEnd)
-                        ++ [last2 False]
+                        ++ [try (last2 False), string "::"]
     choice ipv6variants <?> "bad IPv6 address"
   where
     h4s = (++) <$> hexShortNum <*> string ":"

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -69,8 +69,8 @@ spec = do
         valid isIPv6Address "::ffff:0:255.255.255.255"
         valid isIPv6Address "fe80::7:8%eth0"
         valid isIPv6Address "fe80::7:8%11"
+        valid isIPv6Address "::"
 
-        invalid isIPv6Address "::"
         invalid isIPv6Address "1:2:3:4:5:6:7:8:9"
         invalid isIPv6Address "1:2:3:4:5:6:7:"
         invalid isIPv6Address "1:2:3:4:5:6:7"


### PR DESCRIPTION
[::] was listed in the tests as not valid for IPv6, but it's not only valid, but
common since it is the IPv6 equivalent of 0.0.0.0